### PR TITLE
docs: update storagecard_api to 1.2.0

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -129,5 +129,5 @@ terminal_api_version:
   calypso_legacysam_api: '1.0.0'
   calypso_crypto_symmetric_api: '0.1.1'
   calypso_crypto_asymmetric_api: '0.2.0'
-  storagecard_api: '1.1.1'
+  storagecard_api: '1.2.0'
   genericcard_api: '1.0.0'

--- a/content/community/roadmap/_index.md
+++ b/content/community/roadmap/_index.md
@@ -30,7 +30,7 @@ Possibly late 2026, addition of an interface dedicated to the management of the 
     <td>2026/03/17</td>
     <td>Storage Card API 1.2</td>
     <td>
-    Added method to read system block.
+    Added method to read ST25/SRT512 storage cards system block.
     </td>
   </tr>
   <tr>

--- a/content/community/roadmap/_index.md
+++ b/content/community/roadmap/_index.md
@@ -30,7 +30,7 @@ Possibly late 2026, addition of an interface dedicated to the management of the 
     <td>2026/03/17</td>
     <td>Storage Card API 1.2</td>
     <td>
-    Added method to read ST25/SRT512 storage cards system block.
+    Added method to read ST25/SRT512 storage cards system block during selection.
     </td>
   </tr>
   <tr>

--- a/content/community/roadmap/_index.md
+++ b/content/community/roadmap/_index.md
@@ -26,6 +26,13 @@ Possibly late 2026, addition of an interface dedicated to the management of the 
   </tr>
 </thead>
 <tbody>
+<tr>
+    <td>2026/03/17</td>
+    <td>Storage Card API 1.2</td>
+    <td>
+    Added method to read system block.
+    </td>
+  </tr>
   <tr>
     <td>2026/03/05</td>
     <td>Generic Card API 1.0</td>


### PR DESCRIPTION
[Issue #9](https://github.com/calypsonet-member/keyple-card-cna-storagecard-java-lib/issues/9)